### PR TITLE
テキスト削除時にクラッシュする問題へ対応

### DIFF
--- a/OptionalImageTools/CLTextTool/CLTextSettingView.m
+++ b/OptionalImageTools/CLTextTool/CLTextSettingView.m
@@ -301,14 +301,24 @@
 - (void)textViewDidChange:(UITextView*)textView
 {
     NSRange selection = textView.selectedRange;
-    if(selection.location+selection.length == textView.text.length && [textView.text characterAtIndex:textView.text.length-1] == '\n') {
+
+    if (selection.length == 0 && selection.location == 0) { // KKR 20191130 fix for adding text and then deleting all text
+        [textView scrollRangeToVisible:textView.selectedRange];
+
+        if([self.delegate respondsToSelector:@selector(textSettingView:didChangeText:)]){
+            [self.delegate textSettingView:self didChangeText:NSLocalizedString(@"Text", nil)];
+        }
+
+        return;
+    }
+    else if(selection.location+selection.length == textView.text.length && [textView.text characterAtIndex:textView.text.length-1] == '\n') {
         [textView layoutSubviews];
         [textView scrollRectToVisible:CGRectMake(0, textView.contentSize.height - 1, 1, 1) animated:YES];
     }
     else {
         [textView scrollRangeToVisible:textView.selectedRange];
     }
-    
+
     if([self.delegate respondsToSelector:@selector(textSettingView:didChangeText:)]){
         [self.delegate textSettingView:self didChangeText:textView.text];
     }


### PR DESCRIPTION
## 変更内容

テキスト削除時にクラッシュする問題があるため、下記issueコメントの内容を取り込み。
https://github.com/yackle/CLImageEditor/issues/233

## 検証内容
- 下記パターンのテキスト削除時にクラッシュしないこと
  - 1文字ずつ削除
  - テキスト全削除