### PR TITLE
描画の太さ選択のUISliderが見づらい問題への対応

### DIFF
--- a/CLImageEditor/ImageTools/CLDrawTool/CLDrawTool.m
+++ b/CLImageEditor/ImageTools/CLDrawTool/CLDrawTool.m
@@ -125,8 +125,6 @@ static NSString* const kCLDrawToolEraserIconName = @"eraserIconAssetsName";
     
     [slider setMaximumTrackImage:[UIImage new] forState:UIControlStateNormal];
     [slider setMinimumTrackImage:[UIImage new] forState:UIControlStateNormal];
-    [slider setThumbImage:[UIImage new] forState:UIControlStateNormal];
-    slider.thumbTintColor = [UIColor whiteColor];
     
     return slider;
 }

--- a/OptionalImageTools/CLTextTool/CLTextSettingView.m
+++ b/OptionalImageTools/CLTextTool/CLTextSettingView.m
@@ -301,14 +301,24 @@
 - (void)textViewDidChange:(UITextView*)textView
 {
     NSRange selection = textView.selectedRange;
-    if(selection.location+selection.length == textView.text.length && [textView.text characterAtIndex:textView.text.length-1] == '\n') {
+
+    if (selection.length == 0 && selection.location == 0) { // KKR 20191130 fix for adding text and then deleting all text
+        [textView scrollRangeToVisible:textView.selectedRange];
+
+        if([self.delegate respondsToSelector:@selector(textSettingView:didChangeText:)]){
+            [self.delegate textSettingView:self didChangeText:NSLocalizedString(@"Text", nil)];
+        }
+
+        return;
+    }
+    else if(selection.location+selection.length == textView.text.length && [textView.text characterAtIndex:textView.text.length-1] == '\n') {
         [textView layoutSubviews];
         [textView scrollRectToVisible:CGRectMake(0, textView.contentSize.height - 1, 1, 1) animated:YES];
     }
     else {
         [textView scrollRangeToVisible:textView.selectedRange];
     }
-    
+
     if([self.delegate respondsToSelector:@selector(textSettingView:didChangeText:)]){
         [self.delegate textSettingView:self didChangeText:textView.text];
     }


### PR DESCRIPTION
## 対応内容

- 描画の太さ選択のUISliderが見づらい
  - CLDrawToolのUISlider setThumbImageしている箇所を削除すると、デフォルトUIにある影が付くため見やすくなる

## 検証内容
- 描画メニューを開いてUISliderの表示を確認